### PR TITLE
Issue#53 - Fix for: command line "-option" does not handle boolean values correctly.

### DIFF
--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/Schema2Proto.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/Schema2Proto.java
@@ -395,7 +395,15 @@ public class Schema2Proto {
 			for (String mapping : cmd.getOptionValue(OPTION_OPTIONS).split(",")) {
 				int colon = mapping.indexOf(':');
 				if (colon > -1) {
-					options.put(mapping.substring(0, colon), mapping.substring(colon + 1));
+					String optionName = mapping.substring(0, colon);
+					String parameter = mapping.substring(colon + 1);
+					if (parameter.equals("true")) {
+						options.put(optionName, true);
+					} else if (parameter.equals("false")) {
+						options.put(optionName, false);
+					} else {
+						options.put(optionName, parameter);
+					}
 				} else {
 					LOGGER.error("{} is not a option, use optionName:optionValue", mapping);
 				}


### PR DESCRIPTION
When passing the --options=cc_enable_arenas:true command line option, the code in Schema2Proto.java, parseCommandLineOptions adds everything to the options hashMap as a String. This causes addConfigurationSpecifiedOptions to see treat the value as a string and put quotes around it when adding it to the .proto file.

Note that this behavior is different to how it is handled if the option is read in from a yml file. The values read in from the yml file are correctly added as a Boolean type and therefore are added correctly to the .proto file.

Added code to handle command line options which contain a boolean parameter.  Boolean values are now stored as Boolean and not String in the hashMap.