### PR TITLE
Fix case format determination when second character in string is digit

### DIFF
--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/ProtoSerializer.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/ProtoSerializer.java
@@ -510,13 +510,13 @@ public class ProtoSerializer {
 			}
 		} else {
 			if (Character.isLowerCase(s.charAt(0))) {
-				if (s.matches("([a-z]+[A-Z]+\\w+)+")) {
+				if (s.matches("([a-z]+[A-Z0-9]+\\w+)+")) {
 					return CaseFormat.LOWER_CAMEL;
 				} else if (s.matches("[a-z]+")) {
 					return CaseFormat.LOWER_UNDERSCORE;
 				}
 			} else {
-				if (s.matches("([A-Z]+[a-z]+\\w+)+")) {
+				if (s.matches("([A-Z]+[a-z0-9]+\\w+)+")) {
 					return CaseFormat.UPPER_CAMEL;
 				} else if (s.matches("[A-Z]+")) {
 					return CaseFormat.UPPER_UNDERSCORE;


### PR DESCRIPTION
Current regexp expressions for UPPER_CAMEL ([A-Z]+[a-z]+\w+)+ and LOWER_CAMEL ([a-z]+[A-Z]+\w+)+ cases assume that second character of string may contain only lower/upper case letters, but name may contain also digits.
Current regexp accept Na2me, Nam2e, but not accept N2ame.
We assume that variable/attribute name should not start with digits.

That's why I propose to update regexp with following:
UPPER_CAMEL ([A-Z]+[a-z0-9]+\w+)+
LOWER_CAMEL ([a-z]+[A-Z0-9]+\w+)+