### PR TITLE
Build and test on Java versions and OSes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,24 @@
+name: Java CI build and test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        java: [11, 15]
+      fail-fast: false
+      max-parallel: 4
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Verify with Maven
+        run: mvn verify -B --file pom.xml
+...


### PR DESCRIPTION
By using GitHub CI this will automatically build project and test on Java 11, 15 on Linux and MacOS. Whenever there is a push event.

Signed-off-by: Carl Dea <carl.dea@gmail.com>