### PR TITLE
Resolve doc annotation for complex types from el declaration as fallback

### DIFF
--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
@@ -594,8 +594,10 @@ public class SchemaParser implements ErrorHandler {
 
 			if (messageType == null && !basicTypes.contains(typeName)) {
 
-				// Resolve annotation using complex type if it has annotation, otherwise resolve annotation using the element declaration from complex type scope
-				XSComponent componentForAnnotationResolution = complexType.getAnnotation() != null || complexType.getScope() == null ? complexType : complexType.getScope();
+				// Resolve annotation using complex type if it has annotation, otherwise resolve annotation using the element declaration from complex type
+				// scope
+				XSComponent componentForAnnotationResolution = complexType.getAnnotation() != null || complexType.getScope() == null ? complexType
+						: complexType.getScope();
 				String doc = resolveDocumentationAnnotation(componentForAnnotationResolution, true);
 				Location location = getLocation(complexType);
 

--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
@@ -594,7 +594,9 @@ public class SchemaParser implements ErrorHandler {
 
 			if (messageType == null && !basicTypes.contains(typeName)) {
 
-				String doc = resolveDocumentationAnnotation(complexType, true);
+				// Resolve annotation using complex type if it has annotation, otherwise resolve annotation using the element declaration from complex type scope
+				XSComponent componentForAnnotationResolution = complexType.getAnnotation() != null || complexType.getScope() == null ? complexType : complexType.getScope();
+				String doc = resolveDocumentationAnnotation(componentForAnnotationResolution, true);
 				Location location = getLocation(complexType);
 
 				List<OptionElement> messageOptions = new ArrayList<>();

--- a/schema2proto-lib/src/test/resources/expectedproto/multinamespace/com/schemas/domain/address/com_schemas_domain_address.proto
+++ b/schema2proto-lib/src/test/resources/expectedproto/multinamespace/com/schemas/domain/address/com_schemas_domain_address.proto
@@ -4,6 +4,7 @@ package com.schemas.domain.address;
 
 import "com/schemas/domain/common/com_schemas_domain_common.proto";
 
+// A physical postal address
 message AddressType {
   // Any lines of the address that are not city, postal code or country. For example region, street name and building name/number.
   AddressLinesType address_lines = 1;
@@ -11,6 +12,7 @@ message AddressType {
   string post_code = 3;
   com.schemas.domain.common.Country country = 4;
 
+  // Any lines of the address that are not city, postal code or country. For example region, street name and building name/number.
   message AddressLinesType {
     repeated string line = 1;
   }

--- a/schema2proto-lib/src/test/resources/expectedproto/multinamespace/com/schemas/domain/person/com_schemas_domain_person.proto
+++ b/schema2proto-lib/src/test/resources/expectedproto/multinamespace/com/schemas/domain/person/com_schemas_domain_person.proto
@@ -5,6 +5,7 @@ package com.schemas.domain.person;
 import "com/schemas/domain/address/com_schemas_domain_address.proto";
 import "com/schemas/domain/common/com_schemas_domain_common.proto";
 
+// A person
 message PersonType {
   com.schemas.domain.common.LangType lang = 1;
   string name = 2;


### PR DESCRIPTION
Resolve documentation annotation for complex types using the annotation from the element declaration of the complex type scope when the complex type itself has no annotation.

For example, consider the following element in the source XSD:

```
<xs:element name="person">
    <xs:annotation>
        <xs:documentation>A person</xs:documentation>
    </xs:annotation>
    <xs:complexType>
        <xs:sequence>
            <xs:element name="name" type="xs:string"/>
            <xs:element name="domicile" type="c:country"/>
            <xs:element ref="a:address"/>
        </xs:sequence>
        <xs:attribute ref="c:lang"/>
    </xs:complexType>
</xs:element>
```

## Generated proto

### Before this change

The documentation of the `annotation` node is ignored because it is not inside the complex type but within its element declaration which the current implementation ignores.

```
message PersonType {
  com.schemas.domain.common.LangType lang = 1;
  string name = 2;
  com.schemas.domain.common.Country domicile = 3;
  // A physical postal address
  com.schemas.domain.address.AddressType address = 4;
}
```

### After this change

The documentation of the `annotation` node is used from the element declaration of the complex type as a fallback because the complex type itself has no `annotation` node.

```
// A person
message PersonType {
  com.schemas.domain.common.LangType lang = 1;
  string name = 2;
  com.schemas.domain.common.Country domicile = 3;
  // A physical postal address
  com.schemas.domain.address.AddressType address = 4;
}
```

The NeTEx XSD schema widely uses the format where the `annotation` is placed within the element declaration of the complex type rather than the complex type itself. See for example https://github.com/entur/netex-protobuf/blob/develop/src/main/resources/xsd/netex_part_3/part3_salesTransactions/netex_salesContract_version.xsd#L175 

This change would allow bringing the documentation of the NeTEx XSD types to the generated proto files which is currently left out.