### PR TITLE
Add config option modifyFields to allow modification of existing fields

### DIFF
--- a/schema2proto-lib/example_config/modifyproto.yml
+++ b/schema2proto-lib/example_config/modifyproto.yml
@@ -49,7 +49,8 @@ newFields:
 
 # Modify an existing field on an existing type. Note: All on same line (snake yaml)
 modifyFields:
-  - { targetMessageType: existingPackageName.ExistingMessageType, name: existing_field_name, documentationPattern: "(.*)", documentation: "Replaces matching regex pattern of the existing documentation with this text" }
+  - { targetMessageType: existingPackageName.ExistingMessageType, name: existing_field_name, documentation: "This documentation completely replaces existing documentation on the field." }
+  - { targetMessageType: existingPackageName.ExistingMessageType, name: existing_field_name2, documentationPattern: "(.*)", documentation: "Replaces matching regex pattern of the existing documentation with this text - matching groups supported $1" }
 
 # Add new enum value to existing enum. Note: All on same line (snake yaml)
 newEnumConstants:

--- a/schema2proto-lib/example_config/modifyproto.yml
+++ b/schema2proto-lib/example_config/modifyproto.yml
@@ -47,6 +47,10 @@ newFields:
   - { targetMessageType: existingPackageName.ExistingMessageType, name: field_name,  type: packageName.FieldType, importProto: packageName/file.proto, label: repeated, fieldNumber: 12 }
   - { targetMessageType: existingPackageName.ExistingMessageType, name: field_name_2, type: FieldTypeCommon, importProto: packageName/file2.proto, fieldNumber: 13 }
 
+# Modify an existing field on an existing type. Note: All on same line (snake yaml)
+modifyFields:
+  - { targetMessageType: existingPackageName.ExistingMessageType, name: existing_field_name, documentationPattern: "(.*)", documentation: "Replaces matching regex pattern of the existing documentation with this text" }
+
 # Add new enum value to existing enum. Note: All on same line (snake yaml)
 newEnumConstants:
   - { targetEnumType: existingPackageName.ExistingEnumType, name: ENUM_CONSTANT_TYPE_NEW_VALUE, fieldNumber: 12, documentation: "Enum value documentation" }

--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/modifyproto/ModifyProtoConfigFile.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/modifyproto/ModifyProtoConfigFile.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import no.entur.schema2proto.modifyproto.config.FieldOption;
 import no.entur.schema2proto.modifyproto.config.MergeFrom;
+import no.entur.schema2proto.modifyproto.config.ModifyField;
 import no.entur.schema2proto.modifyproto.config.NewEnumConstant;
 import no.entur.schema2proto.modifyproto.config.NewField;
 
@@ -35,6 +36,7 @@ public class ModifyProtoConfigFile {
 	public List<String> includes;
 	public List<String> excludes;
 	public List<NewField> newFields;
+	public List<ModifyField> modifyFields;
 	public List<MergeFrom> mergeFrom;
 	public List<String> customImportLocations;
 	public List<NewEnumConstant> newEnumConstants;

--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/modifyproto/config/ModifyField.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/modifyproto/config/ModifyField.java
@@ -1,0 +1,46 @@
+/*-
+ * #%L
+ * schema2proto-lib
+ * %%
+ * Copyright (C) 2019 - 2020 Entur
+ * %%
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be
+ * approved by the European Commission - subsequent versions of the
+ * EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * http://ec.europa.eu/idabc/eupl5
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ * #L%
+ */
+package no.entur.schema2proto.modifyproto.config;
+
+public class ModifyField {
+	/**
+	 * Name of the existing message type.
+	 */
+	public String targetMessageType;
+
+	/**
+	 * Name of the field on the existing message type to modify.
+	 */
+	public String field;
+
+	/**
+	 * Regex pattern to match in the existing documentation. If not provided, the existing documentation is completely replaced by
+	 * {@link ModifyField#documentation}.
+	 */
+	public String documentationPattern;
+
+	/**
+	 * Replacement string for the documentation of the existing field. Regex capturing groups from the {@link ModifyField#documentationPattern} are supported.
+	 */
+	public String documentation;
+}

--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/modifyproto/config/ModifyProtoConfiguration.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/modifyproto/config/ModifyProtoConfiguration.java
@@ -33,6 +33,7 @@ public class ModifyProtoConfiguration {
 	public List<String> includes = new ArrayList<>();
 	public List<String> excludes = new ArrayList<>();
 	public List<NewField> newFields = new ArrayList<>();
+	public List<ModifyField> modifyFields = new ArrayList<>();
 	public List<MergeFrom> mergeFrom = new ArrayList<>();
 	public List<String> customImportLocations = new ArrayList<>();
 	public List<NewEnumConstant> newEnumConstants = new ArrayList<>();

--- a/schema2proto-lib/src/test/java/no/entur/schema2proto/modifyproto/ModifyProtoTest.java
+++ b/schema2proto-lib/src/test/java/no/entur/schema2proto/modifyproto/ModifyProtoTest.java
@@ -35,6 +35,7 @@ import no.entur.schema2proto.AbstractMappingTest;
 import no.entur.schema2proto.InvalidConfigurationException;
 import no.entur.schema2proto.modifyproto.config.FieldOption;
 import no.entur.schema2proto.modifyproto.config.MergeFrom;
+import no.entur.schema2proto.modifyproto.config.ModifyField;
 import no.entur.schema2proto.modifyproto.config.ModifyProtoConfiguration;
 import no.entur.schema2proto.modifyproto.config.NewField;
 
@@ -181,6 +182,31 @@ public class ModifyProtoTest extends AbstractMappingTest {
 
 		compareExpectedAndGenerated(expected, "extrafield.proto", generatedRootFolder, "simple.proto");
 
+	}
+
+	@Test
+	public void testModifyField() throws IOException, InvalidProtobufException, InvalidConfigurationException {
+		File expected = new File("src/test/resources/modify/expected/nopackagename").getCanonicalFile();
+		File source = new File("src/test/resources/modify/input/nopackagename").getCanonicalFile();
+
+		ModifyField modifyField = new ModifyField();
+		modifyField.targetMessageType = "A";
+		modifyField.field = "response_timestamp";
+		modifyField.documentationPattern = "(^.*$)";
+		modifyField.documentation = "[Additional documentation] $1";
+
+		ModifyField modifyField2 = new ModifyField();
+		modifyField2.targetMessageType = "B";
+		modifyField2.field = "value";
+		modifyField2.documentationPattern = null;
+		modifyField2.documentation = "Whole documentation replaced";
+
+		ModifyProtoConfiguration configuration = new ModifyProtoConfiguration();
+		configuration.inputDirectory = source;
+		configuration.modifyFields = Arrays.asList(modifyField, modifyField2);
+		modifyProto(configuration);
+
+		compareExpectedAndGenerated(expected, "modifyfield.proto", generatedRootFolder, "simple.proto");
 	}
 
 	@Test

--- a/schema2proto-lib/src/test/resources/modify/expected/nopackagename/modifyfield.proto
+++ b/schema2proto-lib/src/test/resources/modify/expected/nopackagename/modifyfield.proto
@@ -1,0 +1,22 @@
+// default.proto at 0:0
+syntax = "proto3";
+
+// Type for Status of termination response.
+message A {
+    // [Additional documentation] Time individual response element was created.
+    uint64 response_timestamp = 1 [(validate.rules).uint64.gte = 20];
+}
+
+message B {
+    LangType lang = 1;
+    // Whole documentation replaced
+    string value = 2;
+
+}
+
+enum LangType {
+    // Default
+    LANG_TYPE_UNSPECIFIED = 0;
+    LANG_TYPE_A = 1;
+    LANG_TYPE_B = 2;
+}

--- a/schema2proto-wire/src/main/java/com/squareup/wire/schema/Field.java
+++ b/schema2proto-wire/src/main/java/com/squareup/wire/schema/Field.java
@@ -54,7 +54,7 @@ public final class Field {
 	private final Location location;
 	private Label label;
 	private String name;
-	private final String documentation;
+	private String documentation;
 	private int tag;
 	private final String defaultValue;
 	private String elementType;
@@ -299,6 +299,10 @@ public final class Field {
 
 	public void updateName(String newFieldName) {
 		name = newFieldName;
+	}
+
+	public void updateDocumentation(String newDocumentation) {
+		documentation = newDocumentation;
 	}
 
 	public String getElementType() {


### PR DESCRIPTION
New modifyFields config allows to replace existing documentation with a replacement string and optionally also using regex pattern to partially replace existing documentation.