### PR TITLE
Do not add validation rules for optional attributes

### DIFF
--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
@@ -461,17 +461,19 @@ public class SchemaParser implements ErrorHandler {
 	}
 
 	@NotNull
-	private Options getFieldOptions(XSAttributeDecl attributeDecl) {
+	private Options getFieldOptions(XSAttributeDecl attributeDecl, boolean required) {
 		List<OptionElement> optionElements = new ArrayList<>();
 
-		// First see if there are rules associated with attribute declaration
-		List<OptionElement> validationRule = ruleFactory.getValidationRule(attributeDecl);
-		if (!validationRule.isEmpty()) {
-			optionElements.addAll(validationRule);
-		} else {
-			// Check attribute TYPE rules
-			List<OptionElement> typeRule = ruleFactory.getValidationRule(attributeDecl.getType());
-			optionElements.addAll(typeRule);
+		if (required) {
+			// First see if there are rules associated with attribute declaration
+			List<OptionElement> validationRule = ruleFactory.getValidationRule(attributeDecl);
+			if (!validationRule.isEmpty()) {
+				optionElements.addAll(validationRule);
+			} else {
+				// Check attribute TYPE rules
+				List<OptionElement> typeRule = ruleFactory.getValidationRule(attributeDecl.getType());
+				optionElements.addAll(typeRule);
+			}
 		}
 		return new Options(Options.FIELD_OPTIONS, optionElements);
 	}
@@ -845,7 +847,7 @@ public class SchemaParser implements ErrorHandler {
 				String doc = resolveDocumentationAnnotation(decl, false);
 				int tag = messageType.getNextFieldNum();
 				Location fieldLocation = getLocation(decl);
-				Options fieldOptions = getFieldOptions(decl);
+				Options fieldOptions = getFieldOptions(decl, attr.isRequired());
 				String packageName = NamespaceHelper.xmlNamespaceToProtoFieldPackagename(type.getTargetNamespace(), configuration.forceProtoPackage);
 				Label label = type.isList() ? Label.REPEATED : null;
 

--- a/schema2proto-lib/src/test/java/no/entur/schema2proto/generateproto/GenerateValidationRulesTest.java
+++ b/schema2proto-lib/src/test/java/no/entur/schema2proto/generateproto/GenerateValidationRulesTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Collections;
+import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
@@ -69,11 +69,20 @@ public class GenerateValidationRulesTest extends AbstractMappingTest {
 						+ "      min_items: 1\n" + "    }\n" + "  ];\n" + "}\n");
 	}
 
+	@Test
+	public void attributeOptionalPositiveInteger_shouldAllow0() throws IOException {
+		generateProtobuf("test-attribute-positiveInteger.xsd", validationOptions());
+		String generated = IOUtils.toString(Files.newInputStream(Paths.get("target/generated-proto/default/default.proto")), Charset.defaultCharset());
+		Assertions.assertEquals("// default.proto at 0:0\n" + "syntax = \"proto3\";\n" + "package default;\n" + "\n"
+				+ "import \"buf/validate/validate.proto\";\n" + "\n" + "message TestOptionalPositiveIntegerAttribute {\n" + "  uint32 optional_attribute = 1;\n"
+				+ "  uint32 required_attribute = 2 [\n" + "    (buf.validate.field).uint32.gt = 0\n" + "  ];\n" + "}\n", generated);
+	}
+
 	private Schema2ProtoConfiguration validationOptions() {
 		Schema2ProtoConfiguration configuration = new Schema2ProtoConfiguration();
 		configuration.forceProtoPackage = "default";
 		configuration.includeValidationRules = true;
-		configuration.customImportLocations = Collections.singletonList("src/test/resources");
+		configuration.customImportLocations = Arrays.asList("src/test/resources", "target/proto_deps");
 		return configuration;
 	}
 }

--- a/schema2proto-lib/src/test/resources/xsd/test-attribute-positiveInteger.xsd
+++ b/schema2proto-lib/src/test/resources/xsd/test-attribute-positiveInteger.xsd
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1.0">
+    <xsd:complexType name="TestOptionalPositiveIntegerAttribute">
+        <xsd:attribute name="optionalAttribute" use="optional" type="xsd:positiveInteger"/>
+        <xsd:attribute name="requiredAttribute" use="required" type="xsd:positiveInteger"/>
+    </xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
Optional xsd attributes will currently generate protovalidate rules as if they are mandatory.

For instance:
`<attribute name="srsDimension" type="positiveInteger"/>`

generates the following proto definition:
```
uint32 srs_dimension = 22 [
  (buf.validate.field).uint32.gt = 0
];
```

As xsd attributes are default optional the xml will allow omitting srsDimension. The proto schema will, however, require a positive integer value. It should allow omitting the field / specifying 0.

TODO:
How should this be handled? Current impl simply ignores optional attributes. We could probably create separate rule mappings for required/non required, ie mapping "postiveInteger"+required -> `(buf.validate.field).uint32.gt = 0` and  "postiveInteger"+non required -> `(buf.validate.field).uint32.gte = 0` . 

The validation annotation generation does, however, seem quite unfinished in it's current state. For elements it is completely disabled (by `if (false && configuration.includeValidationRules) { // TODO SKIP FOR NOW AS RULES ARE NOT COMPILING`)
   


