### PR TITLE
Support SimpleTypes defined as a union of enums as enums

### DIFF
--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/compatibility/protolock/ProtolockEnumConstant.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/compatibility/protolock/ProtolockEnumConstant.java
@@ -28,7 +28,7 @@ import com.google.gson.annotations.SerializedName;
 
 public class ProtolockEnumConstant extends AbstractNameIDPair {
 
-	private String name;
+	private final String name;
 	@SerializedName("integer")
 	private int id;
 

--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/compatibility/protolock/ProtolockEnumConstant.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/compatibility/protolock/ProtolockEnumConstant.java
@@ -28,7 +28,7 @@ import com.google.gson.annotations.SerializedName;
 
 public class ProtolockEnumConstant extends AbstractNameIDPair {
 
-	private final String name;
+	private String name;
 	@SerializedName("integer")
 	private int id;
 

--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
@@ -247,23 +247,33 @@ public class SchemaParser implements ErrorHandler {
 		} else if (xs.isList()) {
 			nestingLevel--;
 			return processSimpleType(xs.asList().getItemType(), null);
-		} else if (xs.isUnion()) {
-			XSUnionSimpleType unionType = xs.asUnion();
-			boolean allMembersAreEnums = true;
-			for (int i = 0; i < unionType.getMemberSize(); i++) {
-				XSSimpleType member = unionType.getMember(i);
-				if (!member.isRestriction() || member.getFacet(XSFacet.FACET_ENUMERATION) == null) {
-					allMembersAreEnums = false;
-					break;
-				}
-			}
-			if (allMembersAreEnums) {
-				createEnumFromUnion(typeName, unionType);
-			}
+		} else if (isEnumUnion(xs)) {
+			createEnumFromUnion(typeName, xs.asUnion());
 		}
 
 		nestingLevel--;
 		return typeName;
+	}
+
+	private boolean isNonEnumUnion(XSSimpleType xs) {
+		return xs.isUnion() && !isEnumUnion(xs);
+	}
+
+	private boolean isEnumUnion(XSSimpleType xs) {
+		if (!xs.isUnion()) {
+			return false;
+		}
+		XSUnionSimpleType unionType = xs.asUnion();
+		boolean allMembersAreEnums = true;
+
+		for (int i = 0; i < unionType.getMemberSize(); i++) {
+			XSSimpleType member = unionType.getMember(i);
+			if (!member.isRestriction() || member.getFacet(XSFacet.FACET_ENUMERATION) == null) {
+				allMembersAreEnums = false;
+				break;
+			}
+		}
+		return allMembersAreEnums;
 	}
 
 	private void createEnumFromUnion(String typeName, XSUnionSimpleType unionType) {
@@ -546,8 +556,8 @@ public class SchemaParser implements ErrorHandler {
 				XSListSimpleType asList = type.asSimpleType().asList();
 				XSSimpleType itemType = asList.getItemType();
 				typeName = itemType.getName();
-			} else if (type.asSimpleType().isUnion()) {
-				typeName = DEFAULT_PROTO_PRIMITIVE; // Union always resolves to string
+			} else if (isNonEnumUnion(type.asSimpleType())) {
+				typeName = DEFAULT_PROTO_PRIMITIVE; // Non enum union always resolves to string
 			} else {
 				typeName = type.asSimpleType().getBaseType().getName();
 			}
@@ -755,7 +765,7 @@ public class SchemaParser implements ErrorHandler {
 				}
 
 				String name;
-				if (xsSimpleType.isUnion()) {
+				if (isNonEnumUnion(xsSimpleType)) {
 					name = DEFAULT_PROTO_PRIMITIVE;
 				} else {
 					name = xsSimpleType.getName();
@@ -884,7 +894,7 @@ public class SchemaParser implements ErrorHandler {
 			XSAttributeDecl decl = attr.getDecl();
 			XSSimpleType type = decl.getType();
 
-			if (type.getPrimitiveType() != null || type.isList() || type.isUnion()) {
+			if (type.getPrimitiveType() != null || type.isList() || isNonEnumUnion(type)) {
 				String fieldName = decl.getName();
 				String doc = resolveDocumentationAnnotation(decl, false);
 				int tag = messageType.getNextFieldNum();

--- a/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
+++ b/schema2proto-lib/src/main/java/no/entur/schema2proto/generateproto/SchemaParser.java
@@ -84,6 +84,7 @@ import com.sun.xml.xsom.XSSchemaSet;
 import com.sun.xml.xsom.XSSimpleType;
 import com.sun.xml.xsom.XSTerm;
 import com.sun.xml.xsom.XSType;
+import com.sun.xml.xsom.XSUnionSimpleType;
 import com.sun.xml.xsom.impl.ElementDecl;
 import com.sun.xml.xsom.parser.XSOMParser;
 import com.sun.xml.xsom.util.DomAnnotationParserFactory;
@@ -246,10 +247,53 @@ public class SchemaParser implements ErrorHandler {
 		} else if (xs.isList()) {
 			nestingLevel--;
 			return processSimpleType(xs.asList().getItemType(), null);
+		} else if (xs.isUnion()) {
+			XSUnionSimpleType unionType = xs.asUnion();
+			boolean allMembersAreEnums = true;
+			for (int i = 0; i < unionType.getMemberSize(); i++) {
+				XSSimpleType member = unionType.getMember(i);
+				if (!member.isRestriction() || member.getFacet(XSFacet.FACET_ENUMERATION) == null) {
+					allMembersAreEnums = false;
+					break;
+				}
+			}
+			if (allMembersAreEnums) {
+				createEnumFromUnion(typeName, unionType);
+			}
 		}
 
 		nestingLevel--;
 		return typeName;
+	}
+
+	private void createEnumFromUnion(String typeName, XSUnionSimpleType unionType) {
+		Type protoType = getType(unionType.getTargetNamespace(), typeName);
+		if (protoType == null) {
+			Location location = getLocation(unionType);
+			List<EnumConstant> constants = new ArrayList<>();
+			int counter = 1;
+			Set<String> addedValues = new HashSet<>();
+
+			for (int i = 0; i < unionType.getMemberSize(); i++) {
+				XSRestrictionSimpleType member = unionType.getMember(i).asRestriction();
+				for (XSFacet facet : member.getDeclaredFacets()) {
+					String enumValue = facet.getValue().value;
+					if (addedValues.add(enumValue)) {
+						String doc = resolveDocumentationAnnotation(facet, false);
+						List<OptionElement> optionElements = new ArrayList<>();
+						constants.add(new EnumConstant(location, enumValue, counter++, doc, new Options(Options.ENUM_VALUE_OPTIONS, optionElements)));
+					}
+				}
+			}
+
+			List<OptionElement> enumOptionElements = new ArrayList<>();
+			Options enumOptions = new Options(Options.ENUM_OPTIONS, enumOptionElements);
+			String doc = resolveDocumentationAnnotation(unionType, false);
+
+			ProtoType definedProtoType = ProtoType.get(typeName);
+			EnumType enumType = new EnumType(definedProtoType, location, doc, typeName, constants, new ArrayList<>(), enumOptions);
+			addType(unionType.getTargetNamespace(), enumType);
+		}
 	}
 
 	private void addField(MessageType message, Field newField) {

--- a/schema2proto-lib/src/test/java/no/entur/schema2proto/generateproto/SchemaParserTest.java
+++ b/schema2proto-lib/src/test/java/no/entur/schema2proto/generateproto/SchemaParserTest.java
@@ -179,6 +179,12 @@ public class SchemaParserTest extends AbstractMappingTest {
 		compareExpectedAndGenerated(expectedRootFolder, "default/union.proto", generatedRootFolder, "default/default.proto");
 	}
 
+	@Test
+	public void testUnionOfEnums() throws IOException {
+		generateProtobufNoOptions("basic/union-of-enums.xsd");
+		compareExpectedAndGenerated(expectedRootFolder, "default/union-of-enums.proto", generatedRootFolder, "default/default.proto");
+	}
+
 	// @Test
 	public void testValidationRules() throws IOException {
 		generateProtobufNoOptions("basic/validationrules.xsd");

--- a/schema2proto-lib/src/test/resources/expectedproto/basic/default/union-of-enums.proto
+++ b/schema2proto-lib/src/test/resources/expectedproto/basic/default/union-of-enums.proto
@@ -1,0 +1,26 @@
+// default.proto at 0:0
+syntax = "proto3";
+package default;
+
+enum Enum1 {
+  // Default
+  ENUM1_UNSPECIFIED = 0;
+  ENUM1_E_1_VAL_1 = 1;
+  ENUM1_E_1_VAL_2 = 2;
+}
+
+enum Enum2 {
+  // Default
+  ENUM2_UNSPECIFIED = 0;
+  ENUM2_E_2_VAL_1 = 1;
+  ENUM2_E_2_VAL_2 = 2;
+}
+
+enum UnionEnumeration {
+  // Default
+  UNION_ENUMERATION_UNSPECIFIED = 0;
+  UNION_ENUMERATION_E_1_VAL_1 = 1;
+  UNION_ENUMERATION_E_1_VAL_2 = 2;
+  UNION_ENUMERATION_E_2_VAL_1 = 3;
+  UNION_ENUMERATION_E_2_VAL_2 = 4;
+}

--- a/schema2proto-lib/src/test/resources/xsd/basic/union-of-enums.xsd
+++ b/schema2proto-lib/src/test/resources/xsd/basic/union-of-enums.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" version="1.0">
+
+    <xsd:simpleType name="UnionEnumeration">
+        <xsd:union memberTypes="Enum1 Enum2"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="Enum1">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="e1val1"/>
+            <xsd:enumeration value="e1val2"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="Enum2">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="e2val1"/>
+            <xsd:enumeration value="e2val2"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+</xsd:schema>


### PR DESCRIPTION
Types like UnionEnumeration below have been ignored until now:
```
 <xsd:simpleType name="UnionEnumeration">
        <xsd:union memberTypes="Enum1 Enum2"/>
    </xsd:simpleType>

    <xsd:simpleType name="Enum1">
        <xsd:restriction base="xsd:string">
            <xsd:enumeration value="e1val1"/>
            <xsd:enumeration value="e1val2"/>
        </xsd:restriction>
    </xsd:simpleType>

    <xsd:simpleType name="Enum2">
        <xsd:restriction base="xsd:string">
            <xsd:enumeration value="e2val1"/>
            <xsd:enumeration value="e2val2"/>
        </xsd:restriction>
    </xsd:simpleType>
```

How should these be converted to proto? Choicewrapper type may be safest, but fare more messy to work with.

This PR proposes creating enums from the combined enum values of all union members if all values are enums. This makes the use as close to the xsd type as possible, but creates a risk for backwards compatibility issues if union type is later changed to allow non enum values :thinking:  



:warning: Current impl seems to work for the union causing issues in NeTEx 2.0, but is not ready for merging!