### PR TITLE
fix(codeql): add packages: read and pin gha-security to v2.13.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,10 +12,18 @@ on:
   schedule:
     - cron: "0 4 * * TUE" # Run Tuesday at 4AM UTC
 
+permissions:
+  packages: read
+  security-events: write
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   code-scan:
     name: CodeQL Scan
-    uses: entur/gha-security/.github/workflows/code-scan.yml@v2.12.2
+    uses: entur/gha-security/.github/workflows/code-scan.yml@v2
     # no secrets necessary
     permissions: # some of these only apply when running on the default branch
       actions: read


### PR DESCRIPTION
## Summary
- Adds `packages: read` permission required by updated CodeQL action from Team Sikkerhet
- Pins `entur/gha-security` to `aeebe7ddac5952b3ef9f14380e2d5884b42a6c2e` (v2.13.0)

## Files changed
- `.github/workflows/codeql.yml`