### PR TITLE
fix(codeql): move permissions block to job level

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,25 +12,19 @@ on:
   schedule:
     - cron: "0 4 * * TUE" # Run Tuesday at 4AM UTC
 
-permissions:
-  packages: read
-  security-events: write
-  actions: read
-  contents: write
-  issues: write
-  pull-requests: write
 
 jobs:
   code-scan:
     name: CodeQL Scan
     uses: entur/gha-security/.github/workflows/code-scan.yml@v2
     # no secrets necessary
-    permissions: # some of these only apply when running on the default branch
+    permissions:
+      packages: read
+      security-events: write
       actions: read
       contents: write
-      pull-requests: write
-      security-events: write
       issues: write
+      pull-requests: write
     with:
       use_setup_java: true
       java_version: "25"


### PR DESCRIPTION
Move the `permissions:` block from workflow level to job level in `.github/workflows/codeql.yml`.

The workflow-level block is removed and the existing job-level block is updated to include all required permissions (`packages: read` added, all others retained).

`with:`, and all other sections are unchanged.