### PR TITLE
Replace trigger-missed-dependabot-deploy with check-last-workflow-run

### DIFF
--- a/.github/workflows/scheduled-tasks.yml
+++ b/.github/workflows/scheduled-tasks.yml
@@ -6,15 +6,12 @@ on:
       timezone: "Europe/Oslo"
 
 jobs:
-  # Dependabot auto-merges via `gh pr merge --auto` are performed by
-  # GITHUB_TOKEN, so the resulting push on main does not trigger
-  # the deploy workflow. This dispatches the deploy if the latest
-  # commit on main is from dependabot and the deploy has not yet run for it.
-  trigger-missed-dependabot-deploy:
-    uses: entur/abt-gha-public/.github/workflows/trigger-missed-dependabot-deploy.yml@v1
+  check-last-workflow-run:
+    uses: entur/abt-gha-public/.github/workflows/check-last-workflow-run.yml@v1
     with:
-      target-workflow: deploy-main.yml
+      workflow: deploy-main.yml
       target-ref: main
+      trigger-release: true
       channel-id: ${{ vars.ALERT_CHANNEL_ID }}
     secrets: inherit
     permissions:


### PR DESCRIPTION
## Summary
Replaces \`trigger-missed-dependabot-deploy\` with \`check-last-workflow-run\` in the scheduled workflow. The new workflow checks if the latest commit on \`main\` is from dependabot and whether the release/deploy workflow has had a successful run within the last 7 days — if not, it dispatches the workflow.